### PR TITLE
feat: handling multilines results with custom output handler

### DIFF
--- a/lua/neotest-busted/_build_spec.lua
+++ b/lua/neotest-busted/_build_spec.lua
@@ -69,7 +69,7 @@ return function(args)
 	local command = vim.tbl_flatten {
 		vim.g.bustedprg or 'busted',
 		'--output',
-		'json'
+		require('neotest-busted._output-handler').source
 	}
 
 	-- The user has selected a specific node inside the file

--- a/lua/neotest-busted/_output-handler.lua
+++ b/lua/neotest-busted/_output-handler.lua
@@ -1,0 +1,56 @@
+---This is a modified version of the standard JSON output handler from busted.
+---The main difference is that this handler inserts an explicit separator
+---before the JSON result output.  The reason is that busted writes both the
+---standard output from tests and the result of running tests to standard
+---output, potentially mixing the two on the same line.
+
+local io_write = io.write
+local io_flush = io.flush
+
+local M = {}
+
+---Prefix to mark the line containing test results as opposed to the standard
+---output of the test
+M.marker = '::NEOTEST_LINE::'
+
+---Full path to this module so it can be referenced by Neovim.  We have no
+---control over the working directory of the Neovim process, so the output
+---handler has to know its own absolute file path.  Neovim can then require the
+---handler as a module and get this information.
+M.source = debug.getinfo(1).source:sub(2)
+
+function M:__call(_options)
+	local json = require('dkjson')
+	local busted = require('busted')
+	local handler = require('busted.outputHandlers.base')()
+
+	handler.suiteEnd = function()
+		local error_info = {
+			pendings = handler.pendings,
+			successes = handler.successes,
+			failures = handler.failures,
+			errors = handler.errors,
+			duration = handler.getDuration(),
+		}
+		local ok, result = pcall(json.encode, error_info)
+
+		io_write('\n' .. M.marker)
+
+		if ok then
+			io_write(result)
+		else
+			io_write('Failed to encode test results to json: ' .. result)
+		end
+
+		io_write('\n')
+		io_flush()
+
+		return nil, true
+	end
+
+	busted.subscribe({ 'suite', 'end' }, handler.suiteEnd)
+
+	return handler
+end
+
+return setmetatable(M, M)

--- a/lua/neotest-busted/_results.lua
+++ b/lua/neotest-busted/_results.lua
@@ -10,9 +10,17 @@ local writefile = vim.fn.writefile
 ---@param path string  Path to file containing JSON output
 ---@return table output  Arbitrary JSON data from the output
 local function decode_result_output(path)
-	-- Assumption: the output will be all one line.  There might be other junk
-	-- on subsequent lines and we don't want that.
-	local result = vim.json.decode(vim.fn.readfile(path)[1])
+	local marker = require('neotest-busted._output-handler').marker
+	local lines = vim.fn.readfile(path)
+
+	-- NOTE: Searching backwards because there might be a line of regular text
+	-- output which happens to have the same prefix.  We want only the last
+	-- matching line.
+	local line = vim.iter(lines)
+		:rev()
+		:find(function(l) return vim.startswith(l, marker) end)
+		:sub(#marker + 1)
+	local result = vim.json.decode(line)
 
 	-- Write a human-readable representation of the test result to the output
 	-- file. The output file contains JSON which we convert into regular text.

--- a/makefile
+++ b/makefile
@@ -33,6 +33,8 @@ unit-test:
 integration-test:
 	@./test/bin/busted --run integration
 
+test: unit-test integration-test
+
 clean:
 	@# Delete everything except for the trust file
 	@for f in test/xdg/local/state/nvim/*; do ([ "$$(basename $$f)" != 'trust' ] && rm -r "$$f") || true; done

--- a/test/unit/samples/empty.lua
+++ b/test/unit/samples/empty.lua
@@ -1,5 +1,6 @@
 -- An empty test file.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local content = ''
 
@@ -15,7 +16,7 @@ local output = {
 
 return function(tempfile)
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/error-msg-with-esc-seq.lua
+++ b/test/unit/samples/error-msg-with-esc-seq.lua
@@ -1,5 +1,6 @@
 -- Failure where the error message contains escape sequences
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -66,7 +67,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/error-parent-after_each.lua
+++ b/test/unit/samples/error-parent-after_each.lua
@@ -1,5 +1,6 @@
 -- A parent `after_each` throws an error
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -71,7 +72,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted','--output', 'json',  '--filter', 'Arithmetic%sAdditive%sAdds%stwo%snumbers', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--filter', 'Arithmetic%sAdditive%sAdds%stwo%snumbers', '--', tempfile}
 	}
 
 	return content, output, spec, expected_results, {1, 2}

--- a/test/unit/samples/error-parent-before_each.lua
+++ b/test/unit/samples/error-parent-before_each.lua
@@ -1,5 +1,6 @@
 -- A parent `before_each` throws an error
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -71,7 +72,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted','--output', 'json',  '--filter', 'Arithmetic%sAdditive%sAdds%stwo%snumbers', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--filter', 'Arithmetic%sAdditive%sAdds%stwo%snumbers', '--', tempfile}
 	}
 
 	return content, output, spec, expected_results, {1, 2}

--- a/test/unit/samples/single-nested-error.lua
+++ b/test/unit/samples/single-nested-error.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single test nested inside a namespace which always
 -- raises an error.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -70,7 +71,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-nested-failure.lua
+++ b/test/unit/samples/single-nested-failure.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single test nested inside a namespace which always
 -- fails.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -69,7 +70,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-nested-pending.lua
+++ b/test/unit/samples/single-nested-pending.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single test nested inside a namespace which is always
 -- pending.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -64,7 +65,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-nested-success.lua
+++ b/test/unit/samples/single-nested-success.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single test nested inside a namespace which always
 -- succeeds.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -62,7 +63,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-standalone-error.lua
+++ b/test/unit/samples/single-standalone-error.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single successful test not nested inside any
 -- namespaces.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -109,7 +110,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-standalone-failure.lua
+++ b/test/unit/samples/single-standalone-failure.lua
@@ -1,5 +1,6 @@
 -- Test file containing a single failing test not nested inside any namespaces.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -63,7 +64,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-standalone-pending.lua
+++ b/test/unit/samples/single-standalone-pending.lua
@@ -1,5 +1,6 @@
 -- Test file containing a single pending test not nested inside any namespaces.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -62,7 +63,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-standalone-success.lua
+++ b/test/unit/samples/single-standalone-success.lua
@@ -3,6 +3,7 @@
 
 
 local types = require 'neotest.types'
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local content = [[
 it('Always succeeds', function()
@@ -61,7 +62,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/stdout_spec.lua
+++ b/test/unit/stdout_spec.lua
@@ -1,0 +1,24 @@
+-- NOTE: tests tests should be run from within Neovim to make sure the plugin
+-- can handle text output from within a test.  Ideally this should be run as an
+-- end-to-end test, but I cannot figure out how to write these because Neotest
+-- runs everything asynchronously.
+
+local output_handler = require 'neotest-busted._output-handler'
+
+describe('Test which write to standard output', function()
+
+	it('Has an explicit line break', function()
+		print('Some text written to standard output\n')
+		assert.is_true(true)
+	end)
+
+	it('Has no explicit line break', function()
+		print('Some text written to standard output')
+		assert.is_true(true)
+	end)
+
+	it('Contains the result marker from the output handler', function()
+		print(string.format('%sThis could trip us up', output_handler.marker))
+		assert.is_true(true)
+	end)
+end)


### PR DESCRIPTION
Fixes the multiline problem by creating a custom output handler that prepends the json output with a marker.