### PR TITLE
No task dependency

### DIFF
--- a/lua/neotest-busted/_build_spec.lua
+++ b/lua/neotest-busted/_build_spec.lua
@@ -1,6 +1,4 @@
 local conf = require 'neotest-busted._conf'
-local lib  = require 'neotest-busted._lib'
-
 
 ---Collects the name of a node and all its ancestors in order from outer-most
 ---down to the given node.
@@ -18,60 +16,41 @@ local function collect_node_names(node, names)
 	return collect_node_names(parent, names)
 end
 
+---@param tree neotest.Tree
+---@return string[]
+local function get_roots(tree)
+	local data = tree:data()
 
----Returns the name and configuration of the task the test file belongs to, if
----any.
----@param config    table   Busted configuration
----@param file_path string  Path to the test file
----@return string?, table?
-local function detect_task(config, file_path)
-	for k, v in pairs(config) do
-		local roots = v.ROOT
-		if roots and k ~= '_all' and k ~= 'default' then
-			for _, root in ipairs(roots) do
-				if lib.is_in_path(root, file_path) then
-					return k, v
-				end
-			end
-		end
-	end
-end
-
----Given a directory path return a table which maps a task name to a list of
----all -roots of that task below the path
----@param config table
----@param path   string
----@return table<string, string[]>
-local function collect_tasks(config, path)
-	local function below_path(root)
-		return lib.is_in_path(path, root)
+	if data.type ~= 'dir' then
+		return { data.path }
 	end
 
-	local result = {}
-	for k, v in pairs(config) do
-		local roots = vim.tbl_filter(below_path, v.ROOT or {})
-		if #roots > 0 then
-			result[k] = roots
-		end
+	local paths = {}
+	for _, child in ipairs(tree:children()) do
+		local child_paths = get_roots(child)
+		vim.list_extend(paths, child_paths)
 	end
-	return result
+
+	return paths
 end
 
 
 ---@param args neotest.RunArgs
 ---@return nil | neotest.RunSpec | neotest.RunSpec[]
-return function(args)
+local function build_spec(args)
 	local tree = args.tree
 	if not tree then return nil end
 	local data = tree:data()
 	local type = data.type
 
-	local command = vim.tbl_flatten {
+	local command = vim.iter {
 		vim.g.bustedprg or 'busted',
-		'--output',
-		'json'
-	}
+	}:flatten():totable()
 
+	local additional_args = {
+		'--output',
+		require 'neotest-busted._output-handler'.source
+	}
 	-- The user has selected a specific node inside the file
 	if type == 'test' or type == 'namespace' then
 		-- Names joined by space, from outer-most to inner-most
@@ -79,39 +58,25 @@ return function(args)
 		-- Escape special characters
 		filter = filter:gsub('%%', '%%%%'):gsub('%s', '%%s'):gsub('-', '%%-')
 
-		vim.list_extend(command, {'--filter', filter})
+		vim.list_extend(additional_args, {'--filter', filter})
 	end
 
-	local config, _, bustedrc = conf.get()
-	if type == 'test' or type == 'namespace' or type == 'file' then
-		local task = detect_task(config, data.path)
-		if task then
-			vim.list_extend(command, {'--run', task})
-		end
-		if bustedrc then
-			vim.list_extend(command, {'--config-file', bustedrc})
-		end
-		-- Specify the test file exactly to avoid ambiguity
-		vim.list_extend(command, {'--', data.path})
-
-		return {
-			command = command,
-		}
-	elseif type == 'dir' then
-		-- For each task collect its roots which are under the directory
-		local tasks = collect_tasks(config, data.path)
-		local result = {}
-		-- For each task create a separate command with one or more roots
-		for task, roots in pairs(tasks) do
-			local cmd = vim.list_extend({}, command)
-			if bustedrc then
-				vim.list_extend(cmd, {'--config-file', bustedrc})
-			end
-			vim.list_extend(cmd, {'--run', task, '--'})
-			vim.list_extend(cmd, roots)
-			table.insert(result, {command = cmd})
-		end
-		return result
+	local _, _, bustedrc = conf.get()
+	if bustedrc then
+		vim.list_extend(additional_args, { '--config-file', bustedrc })
 	end
-	error(string.format('Unknown node type: %s', type))
+
+	vim.list_extend(additional_args, { '--' })
+	local roots = get_roots(tree)
+	if #roots == 0 then
+		return nil
+	end
+	vim.list_extend(additional_args, roots)
+
+	vim.list_extend(command, additional_args)
+	return {
+		command = command,
+	}
 end
+
+return build_spec

--- a/lua/neotest-busted/_build_spec.lua
+++ b/lua/neotest-busted/_build_spec.lua
@@ -63,10 +63,10 @@ local function build_spec(args)
 
 	local _, _, bustedrc = conf.get()
 	if bustedrc then
-		vim.list_extend(additional_args, { '--config-file', bustedrc })
+		vim.list_extend(additional_args, {'--config-file', bustedrc})
 	end
 
-	vim.list_extend(additional_args, { '--' })
+	vim.list_extend(additional_args, {'--'})
 	local roots = get_roots(tree)
 	if #roots == 0 then
 		return nil

--- a/lua/neotest-busted/_output-handler.lua
+++ b/lua/neotest-busted/_output-handler.lua
@@ -1,0 +1,56 @@
+---This is a modified version of the standard JSON output handler from busted.
+---The main difference is that this handler inserts an explicit separator
+---before the JSON result output.  The reason is that busted writes both the
+---standard output from tests and the result of running tests to standard
+---output, potentially mixing the two on the same line.
+
+local io_write = io.write
+local io_flush = io.flush
+
+local M = {}
+
+---Prefix to mark the line containing test results as opposed to the standard
+---output of the test
+M.marker = '::NEOTEST_LINE::'
+
+---Full path to this module so it can be referenced by Neovim.  We have no
+---control over the working directory of the Neovim process, so the output
+---handler has to know its own absolute file path.  Neovim can then require the
+---handler as a module and get this information.
+M.source = debug.getinfo(1).source:sub(2)
+
+function M:__call(_options)
+	local json = require('dkjson')
+	local busted = require('busted')
+	local handler = require('busted.outputHandlers.base')()
+
+	handler.suiteEnd = function()
+		local error_info = {
+			pendings = handler.pendings,
+			successes = handler.successes,
+			failures = handler.failures,
+			errors = handler.errors,
+			duration = handler.getDuration(),
+		}
+		local ok, result = pcall(json.encode, error_info)
+
+		io_write('\n' .. M.marker)
+
+		if ok then
+			io_write(result)
+		else
+			io_write('Failed to encode test results to json: ' .. result)
+		end
+
+		io_write('\n')
+		io_flush()
+
+		return nil, true
+	end
+
+	busted.subscribe({ 'suite', 'end' }, handler.suiteEnd)
+
+	return handler
+end
+
+return setmetatable(M, M)

--- a/lua/neotest-busted/_results.lua
+++ b/lua/neotest-busted/_results.lua
@@ -10,9 +10,17 @@ local writefile = vim.fn.writefile
 ---@param path string  Path to file containing JSON output
 ---@return table output  Arbitrary JSON data from the output
 local function decode_result_output(path)
-	-- Assumption: the output will be all one line.  There might be other junk
-	-- on subsequent lines and we don't want that.
-	local result = vim.json.decode(vim.fn.readfile(path)[1])
+	local marker = require('neotest-busted._output-handler').marker
+	local lines = vim.fn.readfile(path)
+
+	-- NOTE: Searching backwards because there might be a line of regular text
+	-- output which happens to have the same prefix.  We want only the last
+	-- matching line.
+	local line = vim.iter(lines)
+		:rev()
+		:find(function(l) return vim.startswith(l, marker) end)
+		:sub(#marker + 1)
+	local result = vim.json.decode(line)
 
 	-- Write a human-readable representation of the test result to the output
 	-- file. The output file contains JSON which we convert into regular text.

--- a/makefile
+++ b/makefile
@@ -33,6 +33,8 @@ unit-test:
 integration-test:
 	@./test/bin/busted --run integration
 
+test: unit-test integration-test
+
 clean:
 	@# Delete everything except for the trust file
 	@for f in test/xdg/local/state/nvim/*; do ([ "$$(basename $$f)" != 'trust' ] && rm -r "$$f") || true; done

--- a/test/unit/build_spec_spec.lua
+++ b/test/unit/build_spec_spec.lua
@@ -1,10 +1,11 @@
-local adapter = require 'neotest-busted'
-local conf    = require 'neotest-busted._conf'
-local nio = require 'nio'
-local types = require 'neotest.types'
+local adapter        = require 'neotest-busted'
+local conf           = require 'neotest-busted._conf'
+local nio            = require 'nio'
+local types          = require 'neotest.types'
+local output_handler = require 'neotest-busted._output-handler'.source
 
-local split = vim.fn.split
-local writefile = vim.fn.writefile
+local split          = vim.fn.split
+local writefile      = vim.fn.writefile
 
 
 describe('Building the test run specification', function()
@@ -55,7 +56,13 @@ describe('Building the test run specification', function()
 			return add(x, y)
 		]]
 
-		local expected = {'busted', '--output', 'json', '--', tempfile}
+		local expected = {
+			'busted',
+			'--output',
+			output_handler,
+			'--',
+			tempfile,
+		}
 		assert.are.same(expected, spec.command)
 	end)
 
@@ -69,9 +76,13 @@ describe('Building the test run specification', function()
 		local spec = build_spec(content, key)
 
 		local expected = {
-			'busted', '--output', 'json', '--filter',
+			'busted',
+			'--output',
+			output_handler,
+			'--filter',
 			'Fulfills%sa%stautology,%sa%sself%-evident%s100%%%strue%sstatement',
-			'--', tempfile
+			'--',
+			tempfile,
 		}
 		assert.are.same(expected, spec.command)
 	end)
@@ -90,8 +101,13 @@ describe('Building the test run specification', function()
 		local spec = build_spec(content, tempfile .. '::Arithmetic')
 
 		local expected = {
-			'busted', '--output', 'json', '--filter', 'Arithmetic',
-			'--', tempfile
+			'busted',
+			'--output',
+			output_handler,
+			'--filter',
+			'Arithmetic',
+			'--',
+			tempfile,
 		}
 		assert.are.same(expected, spec.command)
 	end)
@@ -110,9 +126,13 @@ describe('Building the test run specification', function()
 		local spec = build_spec(content, tempfile .. '::Arithmetic::Adds two numbers')
 
 		local expected = {
-			'busted', '--output', 'json',
-			'--filter', 'Arithmetic%sAdds%stwo%snumbers',
-			'--', tempfile
+			'busted',
+			'--output',
+			output_handler,
+			'--filter',
+			'Arithmetic%sAdds%stwo%snumbers',
+			'--',
+			tempfile,
 		}
 		assert.are.same(expected, spec.command)
 	end)
@@ -128,39 +148,18 @@ describe('Building the test run specification', function()
 			conf.set(old_config)
 		end)
 
-		it('Picks the right task', function()
-			local tempdir = vim.fn.fnamemodify(tempfile, ':h')
-			tempfile = tempdir .. '/test/unit/derp_spec.lua'
-			vim.fn.mkdir(tempdir .. '/test/unit', 'p', 448)  -- 448 = 0o700
-			conf.set {
-				unit = {
-					-- NOTE: there can be multiple roots
-					ROOT = {tempdir .. '/test/simple', tempdir .. '/test/unit/'}
-				},
-				integration = {
-					ROOT = {'./test/integration/'}
-				},
-			}
-
-			local spec = build_spec [[
-				describe('Arithmetic', function()
-					it('Adds two numbers', function()
-						assert.is.equal(5, 2 + 3)
-					end)
-					it('Multiplies two numbers', function()
-						assert.is.equal(6, 2 * 3)
-					end)
-				end)
-			]]
-
-			local expected = {'busted', '--output', 'json', '--run', 'unit', '--', tempfile}
-			assert.are.same(expected, spec.command)
-		end)
-
 		it('Specifies the bustedrc file', function()
 			conf.set({_all = {verbose = true}}, 'bustedrc')
 			local spec = build_spec ''
-			local expected = {'busted', '--output', 'json', '--config-file', 'bustedrc', '--', tempfile}
+			local expected = {
+				'busted',
+				'--output',
+				output_handler,
+				'--config-file',
+				'bustedrc',
+				'--',
+				tempfile,
+			}
 			assert.are.same(expected, spec.command)
 		end)
 	end)
@@ -173,14 +172,27 @@ describe('Building the test run specification', function()
 		it('Uses the custom executable', function()
 			vim.g.bustedprg = './test/busted'
 			local spec = build_spec ''
-			local expected = {'./test/busted', '--output', 'json', '--', tempfile}
+			local expected = {
+				'./test/busted',
+				'--output',
+				output_handler,
+				'--',
+				tempfile,
+			}
 			assert.are.same(expected, spec.command)
 		end)
 
 		it('Splices in a custom busted command list', function()
 			vim.g.bustedprg = {'busted', '--verbose'}
 			local spec = build_spec ''
-			local expected = {'busted', '--verbose', '--output', 'json', '--', tempfile}
+			local expected = {
+				'busted',
+				'--verbose',
+				'--output',
+				output_handler,
+				'--',
+				tempfile,
+			}
 			assert.are.same(expected, spec.command)
 		end)
 	end)
@@ -210,9 +222,19 @@ describe('Building the test run specification', function()
 
 		it('Runs all tasks with matching roots', function()
 			local expected = {
-				{command = {'busted', '--output', 'json', '--config-file', 'bustedrc', '--run', 'integration', '--', 'test/integration'}},
-				{command = {'busted', '--output', 'json', '--config-file', 'bustedrc', '--run', 'unit', '--', 'test/unit'}},
+				command = {
+					'busted',
+					'--output',
+					output_handler,
+					'--config-file',
+					'bustedrc',
+					'--',
+					'test/integration/foo_spec.lua',
+					'test/unit/foo_spec.lua',
+				},
 			}
+
+
 
 			-- A directory tree which contains two more directory trees which
 			-- are part of the roots.
@@ -242,8 +264,8 @@ describe('Building the test run specification', function()
 								path = 'test/integration/foo_spec.lua',
 								range = {0, 0, 4, 0},
 								type = 'test',
-							}
-						}
+							},
+						},
 					},
 				}, {
 					{
@@ -265,20 +287,19 @@ describe('Building the test run specification', function()
 								path = 'test/unit/foo_spec.lua',
 								range = {0, 0, 4, 0},
 								type = 'test',
-							}
+							},
 						}
 					},
-
 				}
 			}
 			local dir_tree = types.Tree.from_list(t, function(pos) return pos.id end)
-			local spec = assert(adapter.build_spec {tree = dir_tree, strategy = 'integrated'})
+			local spec = assert(adapter.build_spec { tree = dir_tree, strategy = 'integrated' })
 
 			-- NOTE: The order of specifications is undefined, so we need to
 			-- explicitly sort the two list.
 			local function comp(t1, t2) return t1.command[7] < t2.command[7] end
 			table.sort(expected, comp)
-			table.sort(spec    , comp)
+			table.sort(spec,     comp)
 			assert.are.same(expected, spec)
 		end)
 	end)

--- a/test/unit/samples/empty.lua
+++ b/test/unit/samples/empty.lua
@@ -1,5 +1,6 @@
 -- An empty test file.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local content = ''
 
@@ -15,7 +16,7 @@ local output = {
 
 return function(tempfile)
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/error-msg-with-esc-seq.lua
+++ b/test/unit/samples/error-msg-with-esc-seq.lua
@@ -1,5 +1,6 @@
 -- Failure where the error message contains escape sequences
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -66,7 +67,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/error-parent-after_each.lua
+++ b/test/unit/samples/error-parent-after_each.lua
@@ -1,5 +1,6 @@
 -- A parent `after_each` throws an error
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -71,7 +72,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted','--output', 'json',  '--filter', 'Arithmetic%sAdditive%sAdds%stwo%snumbers', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--filter', 'Arithmetic%sAdditive%sAdds%stwo%snumbers', '--', tempfile}
 	}
 
 	return content, output, spec, expected_results, {1, 2}

--- a/test/unit/samples/error-parent-before_each.lua
+++ b/test/unit/samples/error-parent-before_each.lua
@@ -1,5 +1,6 @@
 -- A parent `before_each` throws an error
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -71,7 +72,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted','--output', 'json',  '--filter', 'Arithmetic%sAdditive%sAdds%stwo%snumbers', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--filter', 'Arithmetic%sAdditive%sAdds%stwo%snumbers', '--', tempfile}
 	}
 
 	return content, output, spec, expected_results, {1, 2}

--- a/test/unit/samples/single-nested-error.lua
+++ b/test/unit/samples/single-nested-error.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single test nested inside a namespace which always
 -- raises an error.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -70,7 +71,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-nested-failure.lua
+++ b/test/unit/samples/single-nested-failure.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single test nested inside a namespace which always
 -- fails.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -69,7 +70,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-nested-pending.lua
+++ b/test/unit/samples/single-nested-pending.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single test nested inside a namespace which is always
 -- pending.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -64,7 +65,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-nested-success.lua
+++ b/test/unit/samples/single-nested-success.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single test nested inside a namespace which always
 -- succeeds.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -62,7 +63,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-standalone-error.lua
+++ b/test/unit/samples/single-standalone-error.lua
@@ -1,6 +1,7 @@
 -- Test file containing a single successful test not nested inside any
 -- namespaces.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -109,7 +110,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-standalone-failure.lua
+++ b/test/unit/samples/single-standalone-failure.lua
@@ -1,5 +1,6 @@
 -- Test file containing a single failing test not nested inside any namespaces.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -63,7 +64,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-standalone-pending.lua
+++ b/test/unit/samples/single-standalone-pending.lua
@@ -1,5 +1,6 @@
 -- Test file containing a single pending test not nested inside any namespaces.
 
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local types = require 'neotest.types'
 
@@ -62,7 +63,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/samples/single-standalone-success.lua
+++ b/test/unit/samples/single-standalone-success.lua
@@ -3,6 +3,7 @@
 
 
 local types = require 'neotest.types'
+local output_handler = require 'neotest-busted._output-handler'.source
 
 local content = [[
 it('Always succeeds', function()
@@ -61,7 +62,7 @@ return function(tempfile)
 	}
 
 	local spec = {
-		command = {'busted', '--output', 'json', '--', tempfile}
+		command = {'busted', '--output', output_handler, '--', tempfile}
 	}
 
 	return content, output, spec, expected_results

--- a/test/unit/stdout_spec.lua
+++ b/test/unit/stdout_spec.lua
@@ -1,0 +1,24 @@
+-- NOTE: tests tests should be run from within Neovim to make sure the plugin
+-- can handle text output from within a test.  Ideally this should be run as an
+-- end-to-end test, but I cannot figure out how to write these because Neotest
+-- runs everything asynchronously.
+
+local output_handler = require 'neotest-busted._output-handler'
+
+describe('Test which write to standard output', function()
+
+	it('Has an explicit line break', function()
+		print('Some text written to standard output\n')
+		assert.is_true(true)
+	end)
+
+	it('Has no explicit line break', function()
+		print('Some text written to standard output')
+		assert.is_true(true)
+	end)
+
+	it('Contains the result marker from the output handler', function()
+		print(string.format('%sThis could trip us up', output_handler.marker))
+		assert.is_true(true)
+	end)
+end)


### PR DESCRIPTION
This updates the algorithm for building commands by removing the dependency on tasks in the `bustedrc` file when the target is of type `dir`. These changes are cumulative with PR #5.