### PR TITLE
No task dependency

### DIFF
--- a/lua/neotest-busted/_build_spec.lua
+++ b/lua/neotest-busted/_build_spec.lua
@@ -1,6 +1,4 @@
 local conf = require 'neotest-busted._conf'
-local lib  = require 'neotest-busted._lib'
-
 
 ---Collects the name of a node and all its ancestors in order from outer-most
 ---down to the given node.
@@ -18,60 +16,41 @@ local function collect_node_names(node, names)
 	return collect_node_names(parent, names)
 end
 
+---@param tree neotest.Tree
+---@return string[]
+local function get_roots(tree)
+	local data = tree:data()
 
----Returns the name and configuration of the task the test file belongs to, if
----any.
----@param config    table   Busted configuration
----@param file_path string  Path to the test file
----@return string?, table?
-local function detect_task(config, file_path)
-	for k, v in pairs(config) do
-		local roots = v.ROOT
-		if roots and k ~= '_all' and k ~= 'default' then
-			for _, root in ipairs(roots) do
-				if lib.is_in_path(root, file_path) then
-					return k, v
-				end
-			end
-		end
-	end
-end
-
----Given a directory path return a table which maps a task name to a list of
----all -roots of that task below the path
----@param config table
----@param path   string
----@return table<string, string[]>
-local function collect_tasks(config, path)
-	local function below_path(root)
-		return lib.is_in_path(path, root)
+	if data.type ~= 'dir' then
+		return { data.path }
 	end
 
-	local result = {}
-	for k, v in pairs(config) do
-		local roots = vim.tbl_filter(below_path, v.ROOT or {})
-		if #roots > 0 then
-			result[k] = roots
-		end
+	local paths = {}
+	for _, child in ipairs(tree:children()) do
+		local child_paths = get_roots(child)
+		vim.list_extend(paths, child_paths)
 	end
-	return result
+
+	return paths
 end
 
 
 ---@param args neotest.RunArgs
 ---@return nil | neotest.RunSpec | neotest.RunSpec[]
-return function(args)
+local function build_spec(args)
 	local tree = args.tree
 	if not tree then return nil end
 	local data = tree:data()
 	local type = data.type
 
-	local command = vim.tbl_flatten {
+	local command = vim.iter {
 		vim.g.bustedprg or 'busted',
-		'--output',
-		require('neotest-busted._output-handler').source
-	}
+	}:flatten():totable()
 
+	local additional_args = {
+		'--output',
+		require 'neotest-busted._output-handler'.source
+	}
 	-- The user has selected a specific node inside the file
 	if type == 'test' or type == 'namespace' then
 		-- Names joined by space, from outer-most to inner-most
@@ -79,39 +58,25 @@ return function(args)
 		-- Escape special characters
 		filter = filter:gsub('%%', '%%%%'):gsub('%s', '%%s'):gsub('-', '%%-')
 
-		vim.list_extend(command, {'--filter', filter})
+		vim.list_extend(additional_args, {'--filter', filter})
 	end
 
-	local config, _, bustedrc = conf.get()
-	if type == 'test' or type == 'namespace' or type == 'file' then
-		local task = detect_task(config, data.path)
-		if task then
-			vim.list_extend(command, {'--run', task})
-		end
-		if bustedrc then
-			vim.list_extend(command, {'--config-file', bustedrc})
-		end
-		-- Specify the test file exactly to avoid ambiguity
-		vim.list_extend(command, {'--', data.path})
-
-		return {
-			command = command,
-		}
-	elseif type == 'dir' then
-		-- For each task collect its roots which are under the directory
-		local tasks = collect_tasks(config, data.path)
-		local result = {}
-		-- For each task create a separate command with one or more roots
-		for task, roots in pairs(tasks) do
-			local cmd = vim.list_extend({}, command)
-			if bustedrc then
-				vim.list_extend(cmd, {'--config-file', bustedrc})
-			end
-			vim.list_extend(cmd, {'--run', task, '--'})
-			vim.list_extend(cmd, roots)
-			table.insert(result, {command = cmd})
-		end
-		return result
+	local _, _, bustedrc = conf.get()
+	if bustedrc then
+		vim.list_extend(additional_args, { '--config-file', bustedrc })
 	end
-	error(string.format('Unknown node type: %s', type))
+
+	vim.list_extend(additional_args, { '--' })
+	local roots = get_roots(tree)
+	if #roots == 0 then
+		return nil
+	end
+	vim.list_extend(additional_args, roots)
+
+	vim.list_extend(command, additional_args)
+	return {
+		command = command,
+	}
 end
+
+return build_spec

--- a/lua/neotest-busted/_build_spec.lua
+++ b/lua/neotest-busted/_build_spec.lua
@@ -63,10 +63,10 @@ local function build_spec(args)
 
 	local _, _, bustedrc = conf.get()
 	if bustedrc then
-		vim.list_extend(additional_args, { '--config-file', bustedrc })
+		vim.list_extend(additional_args, {'--config-file', bustedrc})
 	end
 
-	vim.list_extend(additional_args, { '--' })
+	vim.list_extend(additional_args, {'--'})
 	local roots = get_roots(tree)
 	if #roots == 0 then
 		return nil

--- a/test/unit/build_spec_spec.lua
+++ b/test/unit/build_spec_spec.lua
@@ -27,11 +27,11 @@ describe('Building the test run specification', function()
 		return assert(adapter.build_spec(args))
 	end
 
-	before_each(function() -- Create temporary file
+	before_each(function()  -- Create temporary file
 		tempfile = vim.fn.tempname() .. '.lua'
 	end)
 
-	after_each(function() -- Delete temporary file
+	after_each(function()  -- Delete temporary file
 		if vim.fn.filereadable(tempfile) ~= 0 then
 			vim.fn.delete(tempfile)
 		end
@@ -148,43 +148,6 @@ describe('Building the test run specification', function()
 			conf.set(old_config)
 		end)
 
-		it('Picks the right task', function()
-			local tempdir = vim.fn.fnamemodify(tempfile, ':h')
-			tempfile = tempdir .. '/test/unit/derp_spec.lua'
-			vim.fn.mkdir(tempdir .. '/test/unit', 'p', 448)  -- 448 = 0o700
-			conf.set {
-				unit = {
-					-- NOTE: there can be multiple roots
-					ROOT = {tempdir .. '/test/simple', tempdir .. '/test/unit/'}
-				},
-				integration = {
-					ROOT = {'./test/integration/'}
-				},
-			}
-
-			local spec = build_spec [[
-				describe('Arithmetic', function()
-					it('Adds two numbers', function()
-						assert.is.equal(5, 2 + 3)
-					end)
-					it('Multiplies two numbers', function()
-						assert.is.equal(6, 2 * 3)
-					end)
-				end)
-			]]
-
-			local expected = {
-				'busted',
-				'--output',
-				output_handler,
-				'--run',
-				'unit',
-				'--',
-				tempfile,
-			}
-			assert.are.same(expected, spec.command)
-		end)
-
 		it('Specifies the bustedrc file', function()
 			conf.set({_all = {verbose = true}}, 'bustedrc')
 			local spec = build_spec ''
@@ -259,9 +222,19 @@ describe('Building the test run specification', function()
 
 		it('Runs all tasks with matching roots', function()
 			local expected = {
-				{command = {'busted', '--output', output_handler, '--config-file', 'bustedrc', '--run', 'integration', '--', 'test/integration'}},
-				{command = {'busted', '--output', output_handler, '--config-file', 'bustedrc', '--run', 'unit', '--', 'test/unit'}},
+				command = {
+					'busted',
+					'--output',
+					output_handler,
+					'--config-file',
+					'bustedrc',
+					'--',
+					'test/integration/foo_spec.lua',
+					'test/unit/foo_spec.lua',
+				},
 			}
+
+
 
 			-- A directory tree which contains two more directory trees which
 			-- are part of the roots.


### PR DESCRIPTION
This updates the algorithm for building commands by removing the dependency on tasks in the bustedrc file when the target is of type `dir`.